### PR TITLE
Make labels on latency charts more clear

### DIFF
--- a/pages/api/neon-regional.ts
+++ b/pages/api/neon-regional.ts
@@ -1,6 +1,6 @@
 export const config = {
   runtime: "edge",
-  regions: ["cle1"],
+  regions: ["iad1"],
 };
 
 export { default } from "./neon-global";

--- a/pages/index.tsx
+++ b/pages/index.tsx
@@ -291,16 +291,16 @@ export default function Page() {
                 data={new Array(ATTEMPTS).fill(0).map((_, i) => {
                   return {
                     attempt: `#${i + 1}`,
-                    Regional: data.regional[i]
+                    "Edge function in Washington, D.C., USA": data.regional[i]
                       ? data.regional[i].queryDuration
                       : null,
-                    Global: data.global[i]
+                    "Global Edge function": data.global[i]
                       ? data.global[i].queryDuration
                       : null,
                   };
                 })}
                 index="attempt"
-                categories={['Global', 'Regional']}
+                categories={['Global Edge function', 'Edge function in Washington, D.C., USA']}
                 colors={['indigo', 'cyan']}
                 valueFormatter={dataFormatter}
                 yAxisWidth={48}
@@ -322,14 +322,14 @@ export default function Page() {
                 data={new Array(ATTEMPTS).fill(0).map((_, i) => {
                   return {
                     attempt: `#${i + 1}`,
-                    Regional: data.regional[i]
+                    "Edge function in Washington, D.C., USA": data.regional[i]
                       ? data.regional[i].elapsed
                       : null,
-                    Global: data.global[i] ? data.global[i].elapsed : null,
+                    "Global Edge function": data.global[i] ? data.global[i].elapsed : null,
                   };
                 })}
                 index="attempt"
-                categories={['Global', 'Regional']}
+                categories={['Global Edge function', 'Edge function in Washington, D.C., USA']}
                 colors={['indigo', 'cyan']}
                 valueFormatter={dataFormatter}
                 yAxisWidth={48}


### PR DESCRIPTION
Many people I showed the application to got confused by the Regional results.

Most of them started to understand what's going on only after I explained that Regional is a case when the edge function always runs in Washington instead of the closest region to the client.

It seems that the labels on the chart could be updated to remove this confusion and give more value to people that don't have time to dive deep into the logic of the app.