### PR TITLE
Convex

### DIFF
--- a/.env
+++ b/.env
@@ -1,2 +1,2 @@
-NEXT_PUBLIC_CONVEX_URL="https://warmhearted-scorpion-889.convex.cloud"
+NEXT_PUBLIC_CONVEX_URL="https://warmhearted-scorpion-889.edge.convex.cloud"
 TIGRIS_API_URL="https://api.cell1.us-east-1.aws.tigrisdata.cloud/v1"

--- a/pages/api/convex-global.ts
+++ b/pages/api/convex-global.ts
@@ -6,12 +6,7 @@ export const config = {
   runtime: "edge",
 };
 
-// Make sure we use the Edge endpoints.
-let url = process.env.NEXT_PUBLIC_CONVEX_URL;
-if (!url.endsWith("edge.convex.cloud")) {
-  url = url.replace(/convex.cloud$/g, "edge.convex.cloud");
-}
-
+const url = process.env.NEXT_PUBLIC_CONVEX_URL;
 const convex = new ConvexHttpClient(url);
 
 const start = Date.now();

--- a/pages/api/convex-node.ts
+++ b/pages/api/convex-node.ts
@@ -2,12 +2,7 @@ import { ConvexHttpClient } from "convex/browser";
 import type { NextApiRequest, NextApiResponse } from "next";
 import { api as convexApi } from "../../convex/_generated/api";
 
-// Make sure we use the Edge endpoints.
-let url = process.env.NEXT_PUBLIC_CONVEX_URL;
-if (!url.endsWith("edge.convex.cloud")) {
-  url = url.replace(/convex.cloud$/g, "edge.convex.cloud");
-}
-
+const url = process.env.NEXT_PUBLIC_CONVEX_URL;
 const convex = new ConvexHttpClient(url);
 
 const start = Date.now();


### PR DESCRIPTION
The url was getting edited at runtime unnecessarily. Edits it in `.env` instead.