### PR TITLE
UX improvements

### DIFF
--- a/pages/index.tsx
+++ b/pages/index.tsx
@@ -251,7 +251,7 @@ export default function Page() {
                 value="supabase-drizzle"
                 icon={BoltIcon}
               >
-                Supabase (w/ Drizzle)
+                Supabase (w/ Drizzle ORM)
               </SelectItem>
               <SelectItem
                 data-testid="tidb-cloud"
@@ -291,7 +291,7 @@ export default function Page() {
                 value="xata-drizzle"
                 icon={XataIcon}
               >
-                Xata (w/ Drizzle)
+                Xata (w/ Drizzle ORM)
               </SelectItem>
               <SelectItem
                 data-testid="xata-prisma"

--- a/pages/index.tsx
+++ b/pages/index.tsx
@@ -33,7 +33,7 @@ export default function Page() {
   const [isTestRunning, setIsTestRunning] = useState(false);
   const [shouldTestGlobal, setShouldTestGlobal] = useState(true);
   const [shouldTestRegional, setShouldTestRegional] = useState(true);
-  const [shouldTestNode, setShouldTestNode] = useState(false);
+  const [shouldTestNode, setShouldTestNode] = useState(true);
   const [queryCount, setQueryCount] = useState(1);
   const [dataService, setDataService] = useState('');
   const [data, setData] = useState({
@@ -159,7 +159,13 @@ export default function Page() {
               data-testid="database-dropdown"
               className="max-w-xs"
               placeholder="Select Database"
-              onValueChange={(v) => setDataService(v)}
+              onValueChange={(v) => {
+                console.log(`set data service: `, v)
+                setShouldTestGlobal(!NODE_ONLY.includes(v))
+                setShouldTestRegional(!NODE_ONLY.includes(v))
+                setShouldTestNode(NODE_ONLY.includes(v) || NODE_AVAILABLE.includes(v))
+                setDataService(v)
+              }}
             >
               <SelectItem
                 data-testid="vercel-kv"
@@ -388,16 +394,20 @@ export default function Page() {
           </p>
         </div>
 
-        <div>
+        <div className="flex items-center">
           <Button
             type="button"
             data-testid="run-test"
             onClick={onRunTest}
             loading={isTestRunning}
-            disabled={dataService === ''}
+            disabled={dataService === '' || (!shouldTestGlobal && !shouldTestRegional && !shouldTestNode)}
           >
             Run Test
           </Button>
+          {(!shouldTestGlobal && !shouldTestRegional && !shouldTestNode) &&          
+           <p className="text-gray-600 dark:text-gray-300 text-sm ml-4">
+            You need to select at least one <strong>Location</strong> to run the benchmark.
+          </p>}
         </div>
 
         {data.regional.length || data.global.length || data.node.length ? (

--- a/pages/index.tsx
+++ b/pages/index.tsx
@@ -160,7 +160,7 @@ export default function Page() {
               className="max-w-xs"
               placeholder="Select Database"
               onValueChange={(v) => {
-                console.log(`set data service: `, v)
+                // Reset all checkbox values
                 setShouldTestGlobal(!NODE_ONLY.includes(v))
                 setShouldTestRegional(!NODE_ONLY.includes(v))
                 setShouldTestNode(NODE_ONLY.includes(v) || NODE_AVAILABLE.includes(v))


### PR DESCRIPTION
- proper state management of `shouldTestGlobal`, `shouldTestRegional` and `shouldTestNode`: when selecting a new data service, all available locations are selected by default. (before, the checkbox for Node was disabled by default and there also was a bug where it could happen that non-existing routes were invoked during a benchmark run, leading to 404 errors in the browser console)
- enforce at least one location to be selected; otherwise disable the button and render a little message for the user (see screenshot)
- use consistent naming in data services

![image](https://github.com/vercel-labs/function-database-latency/assets/4058327/db133542-5591-431f-bcaa-e1b6f02b4a1d)
