### PR TITLE
fix: use ctx.waitUntil instead of connection idle timeout

### DIFF
--- a/package.json
+++ b/package.json
@@ -29,6 +29,7 @@
     "@types/node": "20.12.8",
     "@types/react": "18.3.1",
     "@upstash/redis": "^1.28.4",
+    "@vercel/edge": "^1.1.1",
     "@vercel/kv": "^1.0.1",
     "@vercel/postgres": "^0.8.0",
     "@xata.io/client": "^0.29.4",

--- a/package.json
+++ b/package.json
@@ -29,7 +29,7 @@
     "@types/node": "20.12.8",
     "@types/react": "18.3.1",
     "@upstash/redis": "^1.28.4",
-    "@vercel/edge": "^1.1.1",
+    "@vercel/functions": "^1.0.1",
     "@vercel/kv": "^1.0.1",
     "@vercel/postgres": "^0.8.0",
     "@xata.io/client": "^0.29.4",

--- a/pages/api/neon-prisma-global.ts
+++ b/pages/api/neon-prisma-global.ts
@@ -2,24 +2,30 @@ import { NextRequest as Request, NextResponse as Response } from "next/server";
 import { Pool } from '@neondatabase/serverless'
 import { PrismaNeon } from '@prisma/adapter-neon'
 import { PrismaClient } from '@/prisma-neon/prisma-client'
+import { RequestContext } from "@vercel/edge";
 
 export const config = {
   runtime: "edge",
 };
-const pool = new Pool({ connectionString: process.env.NEON_DATABASE_URL, idleTimeoutMillis: 1 })
-const adapter = new PrismaNeon(pool)
-const prisma = new PrismaClient({ adapter })
+
 const start = Date.now()
 
-export default async function api(req: Request) {
+export default async function api(req: Request, ctx: RequestContext) {
   const count = toNumber(new URL(req.url).searchParams.get("count"));
   const time = Date.now();
+
+  const pool = new Pool({ connectionString: process.env.NEON_DATABASE_URL })
+  const adapter = new PrismaNeon(pool)
+  const prisma = new PrismaClient({ adapter })
 
   let data = null;
   for (let i = 0; i < count; i++) {
 
     data = await prisma.employees.findMany({ take: 10 });
   }
+
+  ctx.waitUntil(pool.end());
+  
   return Response.json(
     {
       data,

--- a/pages/api/neon-prisma-global.ts
+++ b/pages/api/neon-prisma-global.ts
@@ -2,7 +2,7 @@ import { NextRequest as Request, NextResponse as Response } from "next/server";
 import { Pool } from '@neondatabase/serverless'
 import { PrismaNeon } from '@prisma/adapter-neon'
 import { PrismaClient } from '@/prisma-neon/prisma-client'
-import { RequestContext } from "@vercel/edge";
+import { waitUntil } from "@vercel/functions";
 
 export const config = {
   runtime: "edge",
@@ -10,7 +10,7 @@ export const config = {
 
 const start = Date.now()
 
-export default async function api(req: Request, ctx: RequestContext) {
+export default async function api(req: Request) {
   const count = toNumber(new URL(req.url).searchParams.get("count"));
   const time = Date.now();
 
@@ -24,7 +24,7 @@ export default async function api(req: Request, ctx: RequestContext) {
     data = await prisma.employees.findMany({ take: 10 });
   }
 
-  ctx.waitUntil(pool.end());
+  waitUntil(pool.end());
   
   return Response.json(
     {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -59,6 +59,9 @@ dependencies:
   '@upstash/redis':
     specifier: ^1.28.4
     version: 1.28.4
+  '@vercel/edge':
+    specifier: ^1.1.1
+    version: 1.1.1
   '@vercel/kv':
     specifier: ^1.0.1
     version: 1.0.1
@@ -968,6 +971,10 @@ packages:
     resolution: {integrity: sha512-UalkSAny/dz1m8giEhD3Y5ru1o+CPHI32wFyS3MyzDzj2TRvEN+lTw+mPwi20ojk0H2gs8TBW3qsrvwuLLy+pA==}
     dependencies:
       crypto-js: 4.2.0
+    dev: false
+
+  /@vercel/edge@1.1.1:
+    resolution: {integrity: sha512-NtKiIbn9Cq6HWGy+qRudz28mz5nxfOJWls5Pnckjw1yCfSX8rhXdvY/il3Sy3Zd5n/sKCM2h7VSCCpJF/oaDrQ==}
     dev: false
 
   /@vercel/kv@1.0.1:

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -59,9 +59,9 @@ dependencies:
   '@upstash/redis':
     specifier: ^1.28.4
     version: 1.28.4
-  '@vercel/edge':
-    specifier: ^1.1.1
-    version: 1.1.1
+  '@vercel/functions':
+    specifier: ^1.0.1
+    version: 1.0.1
   '@vercel/kv':
     specifier: ^1.0.1
     version: 1.0.1
@@ -973,8 +973,9 @@ packages:
       crypto-js: 4.2.0
     dev: false
 
-  /@vercel/edge@1.1.1:
-    resolution: {integrity: sha512-NtKiIbn9Cq6HWGy+qRudz28mz5nxfOJWls5Pnckjw1yCfSX8rhXdvY/il3Sy3Zd5n/sKCM2h7VSCCpJF/oaDrQ==}
+  /@vercel/functions@1.0.1:
+    resolution: {integrity: sha512-YBOEKITWgRWQJg2/0TJaiZOAsJz/OqjBfZO87lBA5PtddNjjEUQQxSlon/ank+RC7laJ/51zMKkv9rgprmLMow==}
+    engines: {node: '>= 16'}
     dev: false
 
   /@vercel/kv@1.0.1:


### PR DESCRIPTION
Removes the use of `idleTimeoutMillis` in favour of a more explicit `ctx.waitUntil(pool.end());`. Thanks for the tip @jawj !