### PR TITLE
use HTTP instead of WebSockets in neon-prisma routes

### DIFF
--- a/pages/api/neon-prisma-global.ts
+++ b/pages/api/neon-prisma-global.ts
@@ -1,31 +1,33 @@
 import { NextRequest as Request, NextResponse as Response } from "next/server";
-import { Pool } from '@neondatabase/serverless'
-import { PrismaNeon } from '@prisma/adapter-neon'
-import { PrismaClient } from '@/prisma-neon/prisma-client'
-import { waitUntil } from "@vercel/functions";
+import { neon } from "@neondatabase/serverless";
+import { PrismaNeonHTTP } from "@prisma/adapter-neon";
+import { PrismaClient } from "@/prisma-neon/prisma-client";
 
 export const config = {
   runtime: "edge",
 };
 
-const start = Date.now()
+  // Use the HTTP connection of the Serverless Driver
+const client = neon(process.env.NEON_DATABASE_URL);
+const adapter = new PrismaNeonHTTP(client);
+const prisma = new PrismaClient({ adapter });
+
+const start = Date.now();
 
 export default async function api(req: Request) {
   const count = toNumber(new URL(req.url).searchParams.get("count"));
   const time = Date.now();
 
-  const pool = new Pool({ connectionString: process.env.NEON_DATABASE_URL })
-  const adapter = new PrismaNeon(pool)
-  const prisma = new PrismaClient({ adapter })
+  // Use the WebSocket connection of the Serverless Driver
+  // const pool = new Pool({ connectionString: process.env.NEON_DATABASE_URL });
+  // const adapter = new PrismaNeonHTTP(pool);
+  // const prisma = new PrismaClient({ adapter });
 
   let data = null;
   for (let i = 0; i < count; i++) {
-
     data = await prisma.employees.findMany({ take: 10 });
   }
 
-  waitUntil(pool.end());
-  
   return Response.json(
     {
       data,

--- a/pages/api/neon-prisma-node.ts
+++ b/pages/api/neon-prisma-node.ts
@@ -1,11 +1,18 @@
 import type { NextApiRequest, NextApiResponse } from "next";
-import { Pool } from '@neondatabase/serverless'
-import { PrismaNeon } from '@prisma/adapter-neon'
+import { neon } from "@neondatabase/serverless";
+import { PrismaNeonHTTP } from "@prisma/adapter-neon";
 import { PrismaClient } from '@/prisma-neon/prisma-client'
 
-const pool = new Pool({ connectionString: process.env.NEON_DATABASE_URL })
-const adapter = new PrismaNeon(pool)
-const prisma = new PrismaClient({ adapter })
+
+// Use the WebSocket connection of the Serverless Driver
+// const pool = new Pool({ connectionString: process.env.NEON_DATABASE_URL })
+// const adapter = new PrismaNeon(pool)
+
+// Use the HTTP connection of the Serverless Driver
+const client = neon(process.env.NEON_DATABASE_URL);
+const adapter = new PrismaNeonHTTP(client);
+const prisma = new PrismaClient({ adapter });
+
 const start = Date.now();
 
 export default async function handler (req: NextApiRequest, res: NextApiResponse) {


### PR DESCRIPTION
The new addition of Prisma ORM with Neon uses the [WebSocket](https://neon.tech/docs/serverless/serverless-driver#use-the-driver-over-websockets) connection of the Neon Serverless Driver while the one with Drizzle uses the [HTTP](https://neon.tech/docs/serverless/serverless-driver#use-the-driver-over-http) connection.

This PR updates this and makes Prisma ORM also use HTTP so that the comparison is based on using the same protocols.

I've left the instantiation of the previous WebSocket connection around in comments as additional context.